### PR TITLE
Fixed portuguese (pt-PT) translation

### DIFF
--- a/languages/pt-PT/notifications.json
+++ b/languages/pt-PT/notifications.json
@@ -1,4 +1,4 @@
 {
     "mentions": "Menções",
-    "user_mentioned_you_in": "<strong>%1</strong> mencionou você em <strong>%2</strong>"
+    "user_mentioned_you_in": "<strong>%1</strong> mencionou-te no tópico <strong>%2</strong>"
 }


### PR DESCRIPTION
The translation for pt-BR was the same as the translation for pt-PT. Now it's fixed.