### PR TITLE
fix: parse post content before sending notification

### DIFF
--- a/library.js
+++ b/library.js
@@ -9,6 +9,7 @@ var nconf = module.parent.require('nconf');
 var db = require.main.require('./src/database');
 var Topics = require.main.require('./src/topics');
 var User = require.main.require('./src/user');
+var Posts = require.main.require('./src/posts');
 var Groups = require.main.require('./src/groups');
 var Notifications = require.main.require('./src/notifications');
 var Privileges = require.main.require('./src/privileges');
@@ -186,7 +187,12 @@ function sendNotificationToUids(postData, uids, nidType, notificationText) {
 	var notification;
 	async.waterfall([
 		function (next) {
-			createNotification(postData, nidType, notificationText, next);
+			Posts.parsePost(postData)
+				.then((parsedPost => next(null, parsedPost)))
+				.catch(next);
+		},
+		function (postObject, next) {
+			createNotification(postObject, nidType, notificationText, next);
 		},
 		function (_notification, next) {
 			notification = _notification;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodebb-plugin-mentions",
-  "version": "2.7.4",
+  "version": "2.7.5",
   "description": "NodeBB Plugin that allows users to mention other users by prepending an '@' sign to their username",
   "main": "library.js",
   "scripts": {


### PR DESCRIPTION
Resolves issue I have created on NodeBB repo: https://github.com/NodeBB/NodeBB/issues/8358

Parse post content before sending notification