### PR TITLE
feat: mention by fullnames

### DIFF
--- a/library.js
+++ b/library.js
@@ -423,12 +423,8 @@ async function filterPrivilegedUids (uids, cid, toPid) {
 }
 
 async function filterDisallowedFullnames (users) {
-	users = await Promise.all(users.map(async (user) => {
-		const userSettings = await User.getSettings(user.uid);
-		return userSettings.showfullname ? user : false;
-	}));
-
-	return users.filter(Boolean);
+	const userSettings = await User.getMultipleUserSettings(users.map(user => user.uid));
+	return users.filter((user, index) => userSettings[index].showfullname);
 }
 
 /*

--- a/library.js
+++ b/library.js
@@ -183,6 +183,11 @@ Mentions.notificationTypes = function (data, callback) {
 	callback(null, data);
 };
 
+Mentions.addFields = function (data, callback) {
+	data.fields.push('fullname');
+	callback(null, data);
+};
+
 function sendNotificationToUids(postData, uids, nidType, notificationText) {
 	if (!uids.length) {
 		return;
@@ -417,6 +422,15 @@ async function filterPrivilegedUids (uids, cid, toPid) {
 	return uids.filter(Boolean);
 }
 
+async function filterDisallowedFullnames (users) {
+	users = await Promise.all(users.map(async (user) => {
+		const userSettings = await User.getSettings(user.uid);
+		return userSettings.showfullname ? user : false;
+	}));
+
+	return users.filter(Boolean);
+}
+
 /*
 	WebSocket methods
 */
@@ -448,20 +462,40 @@ SocketPlugins.mentions.listGroups = function(socket, data, callback) {
 SocketPlugins.mentions.userSearch = async (socket, data) => {
 	// Transparently pass request through to socket user.search handler
 	const socketUser = require.main.require('./src/socket.io/user');
-	const result = await socketUser.search(socket, { query: data.query });
+
+	// Search for usernames
+	let usernameResult = await socketUser.search(socket, { query: data.query });
+	// Strip fullnames from username matches to separate username and fullname matches
+	usernameResult.users = usernameResult.users.map(userObj => {
+		userObj.fullname = null;
+		return userObj;
+	});
+
+	// Search for fullnames if they're not hidden globally
+	let fullnameResult = {users: []};
+	if (!Meta.config.hideFullname) {
+		fullnameResult = await socketUser.search(socket, {query: data.query, searchBy: 'fullname'});
+		// Hide results of users that do not allow their full name to be visible
+		fullnameResult.users = await filterDisallowedFullnames(fullnameResult.users);
+	}
+
+	// Merge results, filter duplicates (from username search, leave fullname results)
+	let users = usernameResult.users.filter(userObj =>
+		fullnameResult.users.filter(userObj2 => userObj.uid === userObj2.uid).length === 0
+	).concat(fullnameResult.users);
 
 	if (Mentions._settings.privilegedDirectReplies !== 'on') {
-		return result;
+		return users;
 	}
 
 	if (data.composerObj) {
 		const cid = Topics.getTopicField(data.composerObj.tid, 'cid');
-		const filteredUids = await filterPrivilegedUids(result.users.map(userObj => userObj.uid), cid, data.composerObj.toPid);
+		const filteredUids = await filterPrivilegedUids(users.map(userObj => userObj.uid), cid, data.composerObj.toPid);
 
-		result.users = result.users.filter((userObj) => filteredUids.includes(userObj.uid));
+		users = users.filter((userObj) => filteredUids.includes(userObj.uid));
 	}
 
-	return result;
-}
+	return users;
+};
 
 module.exports = Mentions;

--- a/plugin.json
+++ b/plugin.json
@@ -12,7 +12,8 @@
 		{ "hook": "action:post.save", "method": "notify" },
 		{ "hook": "action:post.edit", "method": "notify" },
 		{ "hook": "filter:notifications.addFilters", "method": "addFilters" },
-		{ "hook": "filter:user.notificationTypes", "method": "notificationTypes" }
+		{ "hook": "filter:user.notificationTypes", "method": "notificationTypes" },
+		{ "hook": "filter:users.addFields", "method": "addFields" }
 	],
 	"scripts": [
 		"static/autofill.js"


### PR DESCRIPTION
Beside the mentioned functionality in the title, this changes return shape of Mentions.userSearch method from object to an array of users, removes matchCount, timing, pagination, route_users data. AFAICS, Mentions.userSearch is consumed only by the plugin itself and those are not used anywhere, so this looks okay.