### PR TITLE
feat: avatars in mentions

### DIFF
--- a/library.js
+++ b/library.js
@@ -445,7 +445,11 @@ async function stripDisallowedFullnames (users) {
 
 SocketPlugins.mentions.getTopicUsers = async (socket, data) => {
 	const uids = await Topics.getUids(data.tid);
-	return await User.getUsernamesByUids(uids);
+	const users =  await User.getUsers(uids);
+	if (Meta.config.hideFullname) {
+		return users;
+	}
+	return stripDisallowedFullnames(users);
 };
 
 SocketPlugins.mentions.listGroups = function(socket, data, callback) {

--- a/static/autofill.js
+++ b/static/autofill.js
@@ -31,7 +31,7 @@ $(document).ready(function() {
 
 				// Get composer metadata
 				var uuid = data.options.className && data.options.className.match(/dropdown-(.+?)\s/)[1];
-				require(['composer'], function (composer) {
+				require(['composer', 'helpers'], function (composer, helpers) {
 					socket.emit('plugins.mentions.userSearch', {
 						query: term,
 						composerObj: composer.posts[uuid],
@@ -45,8 +45,10 @@ $(document).ready(function() {
 							if (app.user.username && app.user.username === user.username) {
 								return;
 							}
-							// Format suggestions as 'username (fullname)'
-							usernames.push(user.username + (user.fullname ? ' (' + user.fullname + ')' : ''));
+							// Format suggestions as 'avatar username (fullname)'
+							var avatar = helpers.buildAvatar(user, 'sm');
+							var fullname = user.fullname ? '(' + user.fullname + ')' : '';
+							usernames.push(avatar + ' ' + user.username + ' ' + fullname);
 						});
 
 						// Add groups that start with the search term


### PR DESCRIPTION
Beside the title, also added a few more related things into the PR:
- Added avatars and full names to topic users too (the ones that are displayed when only "@" is typed).
- Mention sorting fixed (bug was apparent in topic users and groups)
- Full names are also displayed for username matches (it wasn't before to separate them visually).