### PR TITLE
FIX group display

### DIFF
--- a/controllers.js
+++ b/controllers.js
@@ -5,7 +5,10 @@ var groups = require.main.require('./src/groups');
 var Controllers = module.exports;
 
 Controllers.renderAdminPage = function (req, res, next) {
-	groups.getGroupsFromSet('groups:visible:createtime', req.uid, 0, -1, function(err, groupData) {
+	console.log('load groups');
+	groups.getGroupsFromSet('groups:visible:createtime', 0, -1, function(err, groupData) {
+		console.log('err', err);
+		console.log('groupData', groupData);
 		if (err) {
 			return next(err);
 		}

--- a/controllers.js
+++ b/controllers.js
@@ -5,9 +5,7 @@ var groups = require.main.require('./src/groups');
 var Controllers = module.exports;
 
 Controllers.renderAdminPage = function (req, res, next) {	
-	groups.getGroupsFromSet('groups:visible:createtime', 0, -1, function(err, groupData) {
-		console.log('err', err);
-		console.log('groupData', groupData);
+	groups.getGroupsFromSet('groups:visible:createtime', 0, -1, function(err, groupData) {		
 		if (err) {
 			return next(err);
 		}

--- a/controllers.js
+++ b/controllers.js
@@ -4,8 +4,7 @@ var groups = require.main.require('./src/groups');
 
 var Controllers = module.exports;
 
-Controllers.renderAdminPage = function (req, res, next) {
-	console.log('load groups');
+Controllers.renderAdminPage = function (req, res, next) {	
 	groups.getGroupsFromSet('groups:visible:createtime', 0, -1, function(err, groupData) {
 		console.log('err', err);
 		console.log('groupData', groupData);


### PR DESCRIPTION
- use the correct method definition when getting groups from set (causing that the group names are displayed now correctly)