### PR TITLE
feat: add Hebrew translations for mentions notifications

### DIFF
--- a/languages/he/mentions.json
+++ b/languages/he/mentions.json
@@ -1,0 +1,3 @@
+{
+	"user-mentioned-you-in": "<strong>%1</strong> הזכיר אותך ב <strong>%2</strong>"
+}

--- a/languages/he/notifications.json
+++ b/languages/he/notifications.json
@@ -1,6 +1,7 @@
 {
 	"mentions": "אזכורים",
 	"user-mentioned-you-in": "<strong>%1</strong> הזכיר אותך ב <strong>%2</strong>",
+	"user-mentioned-you-in-room": "<strong>%1</strong> הזכיר אותך ב <strong class=\"text-nowrap\"><i class=\"fa %2\"></i>%3</strong>",
 	"user-mentioned-group-in": "<strong>%1</strong> הזכיר את <strong>%2</strong> ב <strong>%3</strong>",
-	"notificationType_mention": "כאשר מישהו מזכיר אותך"
+	"notificationType-mention": "כאשר מישהו מזכיר אותך"
 }


### PR DESCRIPTION
This pull request adds new Hebrew translations for user mentions and updates existing notification keys in the `languages/he` localization files. The most important changes include adding a new key for mentions in specific rooms and fixing a typo in an existing notification key.

### Localization updates:

* [`languages/he/mentions.json`](diffhunk://#diff-e8f587fe3bf19f06cf00e150588ef36785ab915c64da42dcc5ad528fa680f0d9R1-R3): Added a new translation key, `user-mentioned-you-in`, for when a user is mentioned in a specific context.
* `languages/he/notifications.json`: 
  - Added a new key, `user-mentioned-you-in-room`, for mentions in a specific room, including an icon and room name.
  - Corrected a typo in the `notificationType_mention` key by changing the underscore to a hyphen (`notificationType-mention`).