### PR TITLE
fix: resolve mentions when username ends with a period

### DIFF
--- a/library.js
+++ b/library.js
@@ -32,7 +32,7 @@ const utility = require('./lib/utility');
 
 const parts = {
 	before: '(?<=(^|\\P{L}))', // a single unicode non-letter character or start of line
-	main: '(@[\\p{L}\\d\\-_.@]+(?<!-))', // unicode letters, numbers, dashes, underscores, or periods; negative lookbehind keeps trailing periods so usernames ending in `.` resolve before the fallback below strips them
+	main: '(@[\\p{L}\\d\\-_.@]+(?<!-))', // unicode letters, numbers, dashes, underscores, or periods; negative lookbehind guards against dashes at end
 	after: '((?=\\b)(?=[^-])|(?=[^\\p{L}\\d\\-_.@])|$)', // used to figure out where latin mentions end
 };
 const regex = RegExp(`${parts.before}${parts.main}`, 'gu');

--- a/library.js
+++ b/library.js
@@ -32,7 +32,7 @@ const utility = require('./lib/utility');
 
 const parts = {
 	before: '(?<=(^|\\P{L}))', // a single unicode non-letter character or start of line
-	main: '(@[\\p{L}\\d\\-_.@]+(?<![.-]))', // unicode letters, numbers, dashes, underscores, or periods, negative lookbehind to guard against periods/dashes at end
+	main: '(@[\\p{L}\\d\\-_.@]+(?<!-))', // unicode letters, numbers, dashes, underscores, or periods; negative lookbehind keeps trailing periods so usernames ending in `.` resolve before the fallback below strips them
 	after: '((?=\\b)(?=[^-])|(?=[^\\p{L}\\d\\-_.@])|$)', // used to figure out where latin mentions end
 };
 const regex = RegExp(`${parts.before}${parts.main}`, 'gu');
@@ -440,16 +440,37 @@ Mentions.parseRaw = async (content, type = 'default') => {
 	// Convert matches to anchor html
 	let replacements = new Set();
 	await Promise.all(matches.map(async (match) => {
-		const slug = slugify(match.slice(1));
-		match = removePunctuationSuffix(match);
-		let cid = 0;
+		let slug = slugify(match.slice(1));
+		let uid = await User.getUidByUserslug(slug);
 		let groupExists = 0;
-		const uid = await User.getUidByUserslug(slug);
+		let cid = 0;
 		if (!uid) {
 			({ groupExists, cid } = await utils.promiseParallel({
 				groupExists: Groups.existsBySlug(slug),
 				cid: categories.getCidByHandle(slug),
 			}));
+		}
+		// Fallback: if nothing resolved and the match has trailing punctuation,
+		// strip it and retry. This preserves the "@user." at end-of-sentence
+		// behaviour while also supporting usernames that legitimately end in
+		// a period (which can occur when slugify preserves trailing dots for
+		// non-Latin handles).
+		if (!uid && !groupExists && !cid) {
+			const stripped = removePunctuationSuffix(match);
+			if (stripped !== match && stripped.length > 1) {
+				const strippedSlug = slugify(stripped.slice(1));
+				uid = await User.getUidByUserslug(strippedSlug);
+				if (!uid) {
+					({ groupExists, cid } = await utils.promiseParallel({
+						groupExists: Groups.existsBySlug(strippedSlug),
+						cid: categories.getCidByHandle(strippedSlug),
+					}));
+				}
+				if (uid || groupExists || cid) {
+					slug = strippedSlug;
+					match = stripped;
+				}
+			}
 		}
 
 		if (uid || groupExists || cid) {
@@ -490,9 +511,13 @@ Mentions.parseRaw = async (content, type = 'default') => {
 			return b.user && a.user ? b.user.userslug.length - a.user.userslug.length : 0;
 		})
 		.forEach(({ match, url, user, mentionType }) => {
+			// Escape regex specials in `match` — usernames may legitimately
+			// contain `.` (and slugify preserves it for non-Latin handles),
+			// which would otherwise be interpreted as the regex any-char.
+			const escapedMatch = match.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 			const regex = isLatinMention.test(match) ?
-				RegExp(`${parts.before}${match}${parts.after}`, 'gu') :
-				RegExp(`${parts.before}${match}`, 'gu');
+				RegExp(`${parts.before}${escapedMatch}${parts.after}`, 'gu') :
+				RegExp(`${parts.before}${escapedMatch}`, 'gu');
 			let skip = false;
 			splitContent = splitContent.map((c, i) => {
 				// *Might* not be needed anymore? Check pls...

--- a/test/index.js
+++ b/test/index.js
@@ -190,6 +190,18 @@ describe('parser', () => {
 
 			assert.strictEqual(html, check);
 		});
+		it('should resolve a mention when the username itself ends in a period', async () => {
+			const slugWithDot = `${utils.generateUUID().slice(0, 8)}.`;
+			const dotUid = await user.create({ username: slugWithDot });
+			assert(dotUid);
+
+			const html = await main.parseRaw(`hello @${slugWithDot} there`);
+			assert.strictEqual(
+				html,
+				`hello <a class="plugin-mentions-user plugin-mentions-a" href="/user/${encodeURIComponent(slugWithDot)}" aria-label="Profile: ${slugWithDot}">@<bdi>${slugWithDot}</bdi></a> there`
+			);
+		});
+
 		// re-enable this when NodeBB slugify doesn't strip out `@` from usernames
 		it.skip('should match correctly email-like mentions in all test strings', async () => {
 			const index = string.indexOf('@testUser');


### PR DESCRIPTION
## Summary

The mention regex previously stripped any trailing `.` via a negative lookbehind, so `@שלום.` was matched as `@שלום` even when a user with the slug `שלום.` exists — and the lookup for `שלום` then failed.

This actually happens in practice because:
- `slugify` preserves trailing periods for non-Latin handles (e.g. `slugify('שלום.') === 'שלום.'`).
- `isUserNameValid` accepts `.` as a valid username character, so usernames like `user.` or `שלום.` can be created.

The fix keeps trailing periods in the matched mention, then in the resolver:

1. Try the slug as-is first.
2. If nothing resolves and the match has trailing `!?.`, strip it and retry.

This preserves the existing `@user.` end-of-sentence behaviour (the fallback handles it) while also resolving mentions whose username genuinely ends in a period.

Also escapes regex specials in the resolved `match` before reusing it as a `RegExp` source — usernames containing `.` previously produced a pattern that treated the dot as the any-char metacharacter, which could over-match.

## Repro (before fix)

```js
// user exists: { username: 'שלום.', userslug: 'שלום.' }
await Mentions.parseRaw('hello @שלום. there');
// => 'hello @שלום. there'   (no link — bug)
```

After the fix this produces a proper anchor pointing to `/user/%D7%A9%D7%9C%D7%95%D7%9D.`.

## Test plan

- [x] Added `should resolve a mention when the username itself ends in a period` to the parser tests
- [x] Existing tests in the `regex` and `parser` describes still pass (the `@testUser.` end-of-sentence case now flows through the fallback and produces the same HTML)